### PR TITLE
sqlite3: fix CVE-2025-7709

### DIFF
--- a/meta/recipes-support/sqlite/sqlite3/CVE-2025-7709.patch
+++ b/meta/recipes-support/sqlite/sqlite3/CVE-2025-7709.patch
@@ -1,0 +1,29 @@
+From 9b5debfbda112c66bd166fcfac849eac8b213a79 Mon Sep 17 00:00:00 2001
+From: David Khouya <dkhouya@genetec.com>
+Date: Tue, 16 Sep 2025 12:37:55 -0400
+Subject: [PATCH] Optimize allocation of large tombstone arrays in fts5.
+
+FossilOrigin-Name: 63595b74956a9391f03a273204c80ecd0ba946846b7aa0195b9095fe8b6a78e5
+
+CVE: CVE-2025-7709
+Upstream-Status: Backport [https://github.com/sqlite/sqlite/commit/75b03b9c11e098be39d75e88409e9f223fd7cd31]
+---
+ sqlite3.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sqlite3.c b/sqlite3.c
+index af3deac..fb42adc 100644
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -240754,9 +240754,9 @@ static void fts5SegIterSetNext(Fts5Index *p, Fts5SegIter *pIter){
+ ** leave an error in the Fts5Index object.
+ */
+ static void fts5SegIterAllocTombstone(Fts5Index *p, Fts5SegIter *pIter){
+-  const int nTomb = pIter->pSeg->nPgTombstone;
++  const i64 nTomb = (i64)pIter->pSeg->nPgTombstone;
+   if( nTomb>0 ){
+-    int nByte = nTomb * sizeof(Fts5Data*) + sizeof(Fts5TombstoneArray);
++    i64 nByte = nTomb * sizeof(Fts5Data*) + sizeof(Fts5TombstoneArray);
+     Fts5TombstoneArray *pNew;
+     pNew = (Fts5TombstoneArray*)sqlite3Fts5MallocZero(&p->rc, nByte);
+     if( pNew ){

--- a/meta/recipes-support/sqlite/sqlite3_3.45.3.bb
+++ b/meta/recipes-support/sqlite/sqlite3_3.45.3.bb
@@ -7,6 +7,7 @@ SRC_URI = "http://www.sqlite.org/2024/sqlite-autoconf-${SQLITE_PV}.tar.gz \
            file://CVE-2025-3277.patch \
            file://CVE-2025-29088.patch \
            file://CVE-2025-6965.patch \
+           file://CVE-2025-7709.patch \
           "
 SRC_URI[sha256sum] = "b2809ca53124c19c60f42bf627736eae011afdcc205bb48270a5ee9a38191531"
 


### PR DESCRIPTION
CVE-2025-7709:
SQLite is vulnerable to memory corruption due to an integer overflow in the FTS5 extension that can occur when the size of an array of tombstone pointers is calculated, and that size is then truncated in order to fit into a 32-bit integer. A remote attacker could exploit this vulnerability in order to cause a heap buffer overflow which could result in a denial-of-service condition, or leverage the memory corruption in order to achieve higher impacts.

References:
[https://nvd.nist.gov/vuln/detail/CVE-2025-7709]
[https://github.com/google/security-research/security/advisories/GHSA-v2c8-vqqp-hv3g]